### PR TITLE
Specify the return type of src/fib.ts/fibonacci

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,12 +1,12 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n): number {
   if (n < 0) {
-    return -1;
+    return Number(-1);
   } else if (n == 0) {
-    return 0;
+    return Number(0);
   } else if (n == 1) {
-    return 1;
+    return Number(1);
   }
 
-  return fibonacci(n - 1) + fibonacci(n - 2);
+  return Number(fibonacci(n - 1)) + Number(fibonacci(n - 2));
 }


### PR DESCRIPTION
The return type the fibonacci function in src/fib.ts has been specified. Because of it being trivial, no testing was done.