### PR TITLE
Specify types in src/fibRoute.ts

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,11 +1,12 @@
 // Endpoint for querying the fibonacci numbers
 
 import fibonacci from "./fib";
+import { Request, Response } from 'express';
 
-export default (req, res) => {
+export default (req: Request, res: Response) => {
   const { num } = req.params;
 
-  const fibN = fibonacci(parseInt(num));
+  const fibN: number = fibonacci(parseInt(num));
   let result = `fibonacci(${num}) is ${fibN}`;
 
   if (fibN < 0) {


### PR DESCRIPTION
Types were specified in src/fibRoute.ts. Request and Response were imported from express to specify the types of the req and res arguments. Trivial changes did not change functionality and hence rendered no need to test.